### PR TITLE
Add more multiline fields

### DIFF
--- a/debiancontrol.go
+++ b/debiancontrol.go
@@ -30,6 +30,9 @@ func init() {
 	fieldType["Checksums-Sha1"] = Multiline
 	fieldType["Checksums-Sha256"] = Multiline
 	fieldType["Package-List"] = Multiline
+	fieldType["MD5Sum"] = Multiline
+	fieldType["SHA1"] = Multiline
+	fieldType["SHA256"] = Multiline
 }
 
 // Parses a Debian control file and returns a slice of Paragraphs.


### PR DESCRIPTION
MD5Sum, SHA1 and SHA256 are used in http://deb.debian.org/debian/dists/jessie/Release for example and stripping whitespace makes it very hard to separate the individual hash/length/path fields.