### PR TITLE
Fix link to godoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ func main() {
 
 Find the documentation at:
 
-http://go.pkgdoc.org/github.com/stapelberg/godebiancontrol
+https://godoc.org/github.com/stapelberg/godebiancontrol


### PR DESCRIPTION
The old link points to a domain squatter now.